### PR TITLE
Support talking to legacy JSON-RPC 1.0 servers

### DIFF
--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -528,10 +528,11 @@ def check_for_errors(result):
             code = result['error']['code']
             message = result['error']['message']
             raise ProtocolError((code, message))
-        elif 'reason' in result['error']:
-            raise ProtocolError(result['error']['reason'])
+        elif type(result['error']) is dict and len(result['error']) == 1:
+            error_key = result['error'].keys()[0]
+            raise ProtocolError(result['error'][error_key])
         else:
-            raise ProtocolError(('Malformed result object', result['error']))
+            raise ProtocolError(result['error'])
     return result
 
 def isbatch(result):


### PR DESCRIPTION
I've needed to talk to legacy JSON-RPC 1.0 server and found that there's no library on PyPi that could readily do it.
- Errors are not handled properly, but raise `KeyError` exception (see issue #13);
- In JSON-RPC 1.0 `params` are mandatory, even if empty (see [this commit in alanbriolat/jsonrpclib](https://github.com/alanbriolat/jsonrpclib/commit/f72d8a46b639555cbe5b5ab83d57e147eae759aa) fork).

Here are quick fixes, which I hope could be merged. Error handling modifications should not affect working with any compliant 1.1+ server, but only more eagerly accept possible 1.0 oddities.

Thanks.
