### PR TITLE
adding extra fields to JSON RPC request structure

### DIFF
--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -61,6 +61,8 @@ import jsonrpclib
 from jsonrpclib import config
 from jsonrpclib import history
 
+extra = None
+
 # JSON library importing
 cjson = None
 json = None
@@ -425,6 +427,8 @@ class Payload(dict):
             request['params'] = params
         if self.version >= 2:
             request['jsonrpc'] = str(self.version)
+        if extra:
+            request.update(extra)
         return request
 
     def notify(self, method, params=[]):


### PR DESCRIPTION
Adding custom fields to JSON RPC request.
For use with servers implementing authentication with 'auth' field containing session ID (Zabbix API for example):

``` python
import jsonrpc
server = jsonrpclib.Server('http://www.example.org/zabbix/api_jsonrpc.php')

# call remote login method and read the session ID
sid = server.user.login(user = 'apitest', password = 'atest9')

# set the 'extra' module parameter to contain the session ID
jsonrpclib.jsonrpc.extra = { 'auth': sid }

# go on with other procedures which require authentication, e.g.
server.hostgroup.get(output = 'extend', sortfield = 'name')
```

This may not be the best place to put the extra parameter, if you'd suggest a better way, I'd be glad to rewrite my commit.
