### PR TITLE
Add access to error.data

### DIFF
--- a/jsonrpclib/__init__.py
+++ b/jsonrpclib/__init__.py
@@ -3,4 +3,4 @@ config = Config.instance()
 from jsonrpclib.history import History
 history = History.instance()
 from jsonrpclib.jsonrpc import Server, MultiCall, Fault
-from jsonrpclib.jsonrpc import ProtocolError, loads, dumps
+from jsonrpclib.jsonrpc import ProtocolError, AppError, loads, dumps

--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -109,6 +109,9 @@ def jloads(json_string):
 
 class ProtocolError(Exception):
     pass
+class AppError(ProtocolError):
+    def data(self):
+        return self[0][2]
 
 class TransportMixIn(object):
     """ Just extends the XMLRPC transport where necessary. """
@@ -526,7 +529,11 @@ def check_for_errors(result):
     if 'error' in result.keys() and result['error'] != None:
         code = result['error']['code']
         message = result['error']['message']
-        raise ProtocolError((code, message))
+        if -32700 <= code <= -32000:
+            # pre-defined errors, see http://www.jsonrpc.org/specification#error_object
+            raise ProtocolError((code, message))
+        else:
+            raise AppError((code, message, result['error'].get('data', None)))
     return result
 
 def isbatch(result):


### PR DESCRIPTION
When a JSON-RPC call fails, the server _may_ send additional information in  `error.data`. This change allows access to that data. Now you can do something like:

```
s = jsonrpclib.Server('http://...')
try:
  s.my.method.call(...)
except AppError as e:
  # access e.data() here
except:
  # protocol errors and other stuff go here, as earlier
```
