### PR TITLE
Fixing bug with jsonrpc._Method caused by debugger

### DIFF
--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -276,11 +276,7 @@ class _Method(XML_Method):
             return self.__send(self.__name, kwargs)
 
     def __getattr__(self, name):
-        self.__name = '%s.%s' % (self.__name, name)
-        return self
-        # The old method returned a new instance, but this seemed wasteful.
-        # The only thing that changes is the name.
-        #return _Method(self.__send, "%s.%s" % (self.__name, name))
+        return _Method(self.__send, "%s.%s" % (self.__name, name))
 
     def __repr__(self):
         return '<{} "{}">'.format(self.__class__.__name__, self.__name)

--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -282,6 +282,15 @@ class _Method(XML_Method):
         # The only thing that changes is the name.
         #return _Method(self.__send, "%s.%s" % (self.__name, name))
 
+    def __repr__(self):
+        return '<{} "{}">'.format(self.__class__.__name__, self.__name)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __dir__(self):
+        return self.__dict__.keys()
+
 class _Notify(object):
     def __init__(self, request):
         self._request = request


### PR DESCRIPTION
Whilst debugging jsonrpclib with PyCharm I observed odd behaviour with jsonrpc.\_Method due to pycharm using the \_\_repr\_\_, \_\_str\_\_ and \_\_dir\_\_ methods in order to populate its debug information. These calls would be handled by \_\_getattr\_\_ which would modify the object, corrupting the method name chain. xmlrpclib does not have this issue because it does not make the same optimisation of mutating the existing object but returns a new object when \_\_getattr\_\_ is called (this might actually be a preferable approach to what i am proposing, so consider it as another option).

__UPDATE__:
After working with the library a bit more i think it would be preferable to revert back to the xmlrpclib approach of not mutating \_Method and returning a a new instance each time \_\_getattr\_\_ is called. Because it allows code such as this to work:

    foo_proxy = jsonrpclib.Server('http://localhost:80')
    remote_bar = foo_proxy.objects.bar
    remote_bar.baz()
    remote_bar.qux()

If we mutate the _Method then the 'qux()' call would not behave as expected.

Let me know if there are any questions or concerns.