### PR TITLE
Ability to override Content-Type of RPC request

### DIFF
--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -116,8 +116,14 @@ class TransportMixIn(object):
     # for Python 2.7 support
     _connection = None
 
+    DEFAULT_CONTENT_TYPE = "application/json-rpc"
+
+    def __init__(self, *args, **kwargs):
+        self.content_type = kwargs.pop("content_type", self.DEFAULT_CONTENT_TYPE)
+        super(TransportMixIn, self).__init__(*args, **kwargs)
+
     def send_content(self, connection, request_body):
-        connection.putheader("Content-Type", "application/json-rpc")
+        connection.putheader("Content-Type", self.content_type)
         connection.putheader("Content-Length", str(len(request_body)))
         connection.endheaders()
         if request_body:
@@ -187,7 +193,7 @@ class ServerProxy(XMLServerProxy):
     """
 
     def __init__(self, uri, transport=None, encoding=None, 
-                 verbose=0, version=None):
+                 verbose=0, version=None, content_type=None):
         import urllib
         if not version:
             version = config.version
@@ -209,11 +215,11 @@ class ServerProxy(XMLServerProxy):
                 self.__handler == '/'
         if transport is None:
             if schema == 'unix':
-                transport = UnixTransport()
+                transport = UnixTransport(content_type=content_type)
             elif schema == 'https':
-                transport = SafeTransport()
+                transport = SafeTransport(content_type=content_type)
             else:
-                transport = Transport()
+                transport = Transport(content_type=content_type)
         self.__transport = transport
         self.__encoding = encoding
         self.__verbose = verbose


### PR DESCRIPTION
Some JSON-RPC APIs (Atlassian Confluence in my case) do require `Content-Type` other than `application/json-rpc` to work. That little patch adds the ability to make them happy.

`ServerProxy` can be instantiated as usual but with additional _keyword-only_ parameter `content_type` containing the string to be passed under `Content-Type` HTTP header value:

```
server = jsonrpclib.jsonrpc.ServerProxy(endpoint, content_type="application/json")
```
