### PR TITLE
Update for Python 3k compatibility

### DIFF
--- a/jsonrpclib/SimpleJSONRPCServer.py
+++ b/jsonrpclib/SimpleJSONRPCServer.py
@@ -58,7 +58,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
         response = None
         try:
             request = jsonrpclib.loads(data)
-        except Exception, e:
+        except Exception as e:
             fault = Fault(-32700, 'Request %s invalid. (%s)' % (data, e))
             response = fault.response()
             return response
@@ -167,7 +167,7 @@ class SimpleJSONRPCRequestHandler(
             data = ''.join(L)
             response = self.server._marshaled_dispatch(data)
             self.send_response(200)
-        except Exception, e:
+        except Exception as e:
             self.send_response(500)
             err_lines = traceback.format_exc().splitlines()
             trace_string = '%s | %s' % (err_lines[-3], err_lines[-1])

--- a/jsonrpclib/SimpleJSONRPCServer.py
+++ b/jsonrpclib/SimpleJSONRPCServer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import jsonrpclib
 from jsonrpclib import Fault
 from jsonrpclib.jsonrpc import USE_UNIX_SOCKETS
@@ -221,9 +222,9 @@ class CGIJSONRPCRequestHandler(SimpleJSONRPCDispatcher):
 
     def handle_jsonrpc(self, request_text):
         response = self._marshaled_dispatch(request_text)
-        print 'Content-Type: application/json-rpc'
-        print 'Content-Length: %d' % len(response)
-        print
+        print('Content-Type: application/json-rpc')
+        print('Content-Length: %d' % len(response))
+        print()
         sys.stdout.write(response)
 
     handle_xmlrpc = handle_jsonrpc

--- a/jsonrpclib/SimpleJSONRPCServer.py
+++ b/jsonrpclib/SimpleJSONRPCServer.py
@@ -25,7 +25,7 @@ def get_version(request):
     return None
     
 def validate_request(request):
-    if type(request) is not types.DictType:
+    if type(request) is not dict:
         fault = Fault(
             -32600, 'Request must be {}, not %s.' % type(request)
         )
@@ -38,8 +38,8 @@ def validate_request(request):
     request.setdefault('params', [])
     method = request.get('method', None)
     params = request.get('params')
-    param_types = (types.ListType, types.DictType, types.TupleType)
-    if not method or type(method) not in types.StringTypes or \
+    param_types = (list, dict, tuple)
+    if not method or type(method) not in str or \
         type(params) not in param_types:
         fault = Fault(
             -32600, 'Invalid request parameters or method.', rpcid=rpcid
@@ -65,7 +65,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
         if not request:
             fault = Fault(-32600, 'Request invalid -- no request data.')
             return fault.response()
-        if type(request) is types.ListType:
+        if type(request) is list:
             # This SHOULD be a batch, by spec
             responses = []
             for req_entry in request:
@@ -133,7 +133,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
                         pass
         if func is not None:
             try:
-                if type(params) is types.ListType:
+                if type(params) is list:
                     response = func(*params)
                 else:
                     response = func(**params)

--- a/jsonrpclib/SimpleJSONRPCServer.py
+++ b/jsonrpclib/SimpleJSONRPCServer.py
@@ -7,11 +7,12 @@ if sys.version_info < (3,):
     from SimpleXMLRPCServer import SimpleXMLRPCDispatcher
     from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler
     from SimpleXMLRPCServer import resolve_dotted_attribute
+    from SocketServer import TCPServer
 else:
     from xmlrpc.server import SimpleXMLRPCDispatcher
     from xmlrpc.server import SimpleXMLRPCRequestHandler
     from xmlrpc.server import resolve_dotted_attribute
-import SocketServer
+    from socketserver import TCPServer
 import socket
 import logging
 import os
@@ -187,7 +188,7 @@ class SimpleJSONRPCRequestHandler(SimpleXMLRPCRequestHandler):
         self.wfile.flush()
         self.connection.shutdown(1)
 
-class SimpleJSONRPCServer(SocketServer.TCPServer, SimpleJSONRPCDispatcher):
+class SimpleJSONRPCServer(TCPServer, SimpleJSONRPCDispatcher):
 
     allow_reuse_address = True
 
@@ -211,9 +212,9 @@ class SimpleJSONRPCServer(SocketServer.TCPServer, SimpleJSONRPCDispatcher):
                     logging.warning("Could not unlink socket %s", addr)
         # if python 2.5 and lower
         if vi[0] < 3 and vi[1] < 6:
-            SocketServer.TCPServer.__init__(self, addr, requestHandler)
+            TCPServer.__init__(self, addr, requestHandler)
         else:
-            SocketServer.TCPServer.__init__(self, addr, requestHandler,
+            TCPServer.__init__(self, addr, requestHandler,
                 bind_and_activate)
         if fcntl is not None and hasattr(fcntl, 'FD_CLOEXEC'):
             flags = fcntl.fcntl(self.fileno(), fcntl.F_GETFD)

--- a/jsonrpclib/jsonclass.py
+++ b/jsonrpclib/jsonclass.py
@@ -58,7 +58,7 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[]):
         # It's a dict...
         else:
             new_obj = {}
-            for key, value in obj.iteritems():
+            for key, value in obj.items():
                 new_obj[key] = dump(value, serialize_method,
                                      ignore_attribute, ignore)
             return new_obj
@@ -84,7 +84,7 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[]):
     return_obj['__jsonclass__'].append([])
     attrs = {}
     ignore_list = getattr(obj, ignore_attribute, [])+ignore
-    for attr_name, attr_value in obj.__dict__.iteritems():
+    for attr_name, attr_value in obj.__dict__.items():
         if type(attr_value) in supported_types and \
                 attr_name not in ignore_list and \
                 attr_value not in ignore_list:
@@ -104,7 +104,7 @@ def load(obj):
     # Othewise, it's a dict type
     if '__jsonclass__' not in obj.keys():
         return_dict = {}
-        for key, value in obj.iteritems():
+        for key, value in obj.items():
             new_value = load(value)
             return_dict[key] = new_value
         return return_dict
@@ -149,7 +149,7 @@ def load(obj):
         new_obj = json_class(**params)
     else:
         raise TranslationError('Constructor args must be a dict or list.')
-    for key, value in obj.iteritems():
+    for key, value in obj.items():
         if key == '__jsonclass__':
             continue
         setattr(new_obj, key, value)

--- a/jsonrpclib/jsonclass.py
+++ b/jsonrpclib/jsonclass.py
@@ -2,32 +2,36 @@ import types
 import inspect
 import re
 import traceback
+import sys
 
 from jsonrpclib import config
 
 iter_types = [
-    types.DictType,
-    types.ListType,
-    types.TupleType
+    dict,
+    list,
+    tuple
 ]
 
 string_types = [
-    types.StringType,
-    types.UnicodeType
+    bytes,
+    str
 ]
 
 numeric_types = [
-    types.IntType,
-    types.LongType,
-    types.FloatType
+    int,
+    float
 ]
 
 value_types = [
-    types.BooleanType,
-    types.NoneType
+    bool,
+    type(None)
 ]
 
-supported_types = iter_types+string_types+numeric_types+value_types
+# Python < 3 distinguishes int and long
+if sys.version_info < (3,):
+    numeric_types.append(long)
+
+supported_types = iter_types + string_types + numeric_types + value_types
 invalid_module_chars = r'[^a-zA-Z0-9\_\.]'
 
 class TranslationError(Exception):
@@ -43,12 +47,12 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[]):
     if obj_type in numeric_types+string_types+value_types:
         return obj
     if obj_type in iter_types:
-        if obj_type in (types.ListType, types.TupleType):
+        if obj_type in (list, tuple):
             new_obj = []
             for item in obj:
                 new_obj.append(dump(item, serialize_method,
                                      ignore_attribute, ignore))
-            if obj_type is types.TupleType:
+            if obj_type is tuple:
                 new_obj = tuple(new_obj)
             return new_obj
         # It's a dict...
@@ -92,7 +96,7 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[]):
 def load(obj):
     if type(obj) in string_types+numeric_types+value_types:
         return obj
-    if type(obj) is types.ListType:
+    if type(obj) is list:
         return_list = []
         for entry in obj:
             return_list.append(load(entry))
@@ -139,9 +143,9 @@ def load(obj):
         json_class = getattr(temp_module, json_class_name)
     # Creating the object...
     new_obj = None
-    if type(params) is types.ListType:
+    if type(params) is list:
         new_obj = json_class(*params)
-    elif type(params) is types.DictType:
+    elif type(params) is dict:
         new_obj = json_class(**params)
     else:
         raise TranslationError('Constructor args must be a dict or list.')

--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -421,7 +421,7 @@ class Payload(dict):
         self.version = float(version)
     
     def request(self, method, params=[]):
-        if type(method) not in types.StringTypes:
+        if type(method) not in str:
             raise ValueError('Method name must be a string.')
         if not self.id:
             self.id = random_id()
@@ -465,8 +465,8 @@ def dumps(params=[], methodname=None, methodresponse=None,
     """
     if not version:
         version = config.version
-    valid_params = (types.TupleType, types.ListType, types.DictType)
-    if methodname in types.StringTypes and \
+    valid_params = (tuple, list, dict)
+    if methodname in str and \
             type(params) not in valid_params and \
             not isinstance(params, Fault):
         """ 
@@ -482,7 +482,7 @@ def dumps(params=[], methodname=None, methodresponse=None,
     if type(params) is Fault:
         response = payload.error(params.faultCode, params.faultString)
         return jdumps(response, encoding=encoding)
-    if type(methodname) not in types.StringTypes and methodresponse != True:
+    if type(methodname) not in str and methodresponse != True:
         raise ValueError('Method name must be a string, or methodresponse '+
                          'must be set to True.')
     if config.use_jsonclass == True:
@@ -522,7 +522,7 @@ def check_for_errors(result):
     if not result:
         # Notification
         return result
-    if type(result) is not types.DictType:
+    if type(result) is not dict:
         raise TypeError('Response is not a dict.')
     if 'jsonrpc' in result.keys() and float(result['jsonrpc']) > 2.0:
         raise NotImplementedError('JSON-RPC version not yet supported.')
@@ -535,11 +535,11 @@ def check_for_errors(result):
     return result
 
 def isbatch(result):
-    if type(result) not in (types.ListType, types.TupleType):
+    if type(result) not in (list, tuple):
         return False
     if len(result) < 1:
         return False
-    if type(result[0]) is not types.DictType:
+    if type(result[0]) is not dict:
         return False
     if 'jsonrpc' not in result[0].keys():
         return False

--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -46,12 +46,18 @@ appropriately.
 See http://code.google.com/p/jsonrpclib/ for more info.
 """
 
-import types
 import sys
-from xmlrpclib import Transport as XMLTransport
-from xmlrpclib import SafeTransport as XMLSafeTransport
-from xmlrpclib import ServerProxy as XMLServerProxy
-from xmlrpclib import _Method as XML_Method
+# Xmlrpc is split into client and server sub-modules in Python 3. 
+if sys.version_info < (3,):
+    from xmlrpclib import Transport as XMLTransport
+    from xmlrpclib import SafeTransport as XMLSafeTransport
+    from xmlrpclib import ServerProxy as XMLServerProxy
+    from xmlrpclib import _Method as XML_Method
+else:
+    from xmlrpc.client import Transport as XMLTransport
+    from xmlrpc.client import SafeTransport as XMLSafeTransport
+    from xmlrpc.client import ServerProxy as XMLServerProxy
+    from xmlrpc.client import _Method as XML_Method
 import time
 import string
 import random

--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -202,11 +202,14 @@ class ServerProxy(XMLServerProxy):
 
     def __init__(self, uri, transport=None, encoding=None, 
                  verbose=0, version=None):
-        import urllib
+        if sys.version_info < (3,):
+            from urllib import splittype, splithost
+        else:
+            from urllib.parse import splittype, splithost
         if not version:
             version = config.version
         self.__version = version
-        schema, uri = urllib.splittype(uri)
+        schema, uri = splittype(uri)
         if schema not in ('http', 'https', 'unix'):
             raise IOError('Unsupported JSON-RPC protocol.')
         if schema == 'unix':
@@ -216,7 +219,7 @@ class ServerProxy(XMLServerProxy):
             self.__host = uri
             self.__handler = '/'
         else:
-            self.__host, self.__handler = urllib.splithost(uri)
+            self.__host, self.__handler = splithost(uri)
             if not self.__handler:
                 # Not sure if this is in the JSON spec?
                 #self.__handler = '/'

--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -433,7 +433,7 @@ class Payload(dict):
         self.version = float(version)
     
     def request(self, method, params=[]):
-        if type(method) not in str:
+        if type(method) is not str:
             raise ValueError('Method name must be a string.')
         if not self.id:
             self.id = random_id()
@@ -477,8 +477,8 @@ def dumps(params=[], methodname=None, methodresponse=None,
     """
     if not version:
         version = config.version
-    valid_params = (tuple, list, dict)
-    if methodname in str and \
+    valid_params = [tuple, list, dict]
+    if methodname is str and \
             type(params) not in valid_params and \
             not isinstance(params, Fault):
         """ 
@@ -494,7 +494,7 @@ def dumps(params=[], methodname=None, methodresponse=None,
     if type(params) is Fault:
         response = payload.error(params.faultCode, params.faultString)
         return jdumps(response, encoding=encoding)
-    if type(methodname) not in str and methodresponse != True:
+    if type(methodname) is not str and methodresponse != True:
         raise ValueError('Method name must be a string, or methodresponse '+
                          'must be set to True.')
     if config.use_jsonclass == True:

--- a/tests.py
+++ b/tests.py
@@ -34,7 +34,7 @@ except ImportError:
     import simplejson as json
 from threading import Thread
 
-PORTS = range(8000, 8999)
+PORTS = list(range(8000, 8999))
 
 class TestCompatibility(unittest.TestCase):
     

--- a/tests.py
+++ b/tests.py
@@ -449,8 +449,8 @@ def server_set_up(addr, address_family=socket.AF_INET):
     return server_proc
 
 if __name__ == '__main__':
-    print "==============================================================="
-    print "  NOTE: There may be threading exceptions after tests finish.  "
-    print "==============================================================="
+    print("===============================================================")
+    print("  NOTE: There may be threading exceptions after tests finish.  ")
+    print("===============================================================")
     time.sleep(2)
     unittest.main()


### PR DESCRIPTION
This PR updates the jsonrpclib package for Python 3.x (py3k) compatibility.

Most of the commits are syntax updates. Some libraries must also be imported differently depending on whether the Python version is 2.x or 3.x.

The `UnixTransport` was using `httplib.HTTP` - a very outdated means of establishing a HTTP connection which was deprecated in 2.x, (but still included for 1.5.2 compatibility) and completely removed in 3.x. This transport has thus been updated to funciton in a similar way to the latest `xmlrpc.client` code. It _should_ work, but I have no simple means of testing it.