### PR TITLE
Added README to Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.txt
+include README.md


### PR DESCRIPTION
Missing README to manifest, causes pip to fail installation.

fixes #8
