### PR TITLE
Use tox tests to catch distribution issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '2.6'
 install:
 - pip install -r dev-requirements.txt
 - pip install twine
-script: nosetests tests.py --with-coverage --cover-package=jsonrpclib
+script: tox
 deploy:
   provider: pypi
   user: joshmarshall

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,11 @@
 coverage==4.0
 linecache2==1.0.0
 nose==1.3.7
+pluggy==0.3.1
+py==1.4.30
 six==1.9.0
+tox==2.1.1
 traceback2==1.4.0
 unittest2==1.1.0
+virtualenv==13.1.2
+wheel==0.24.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py26,py27
+[testenv]
+deps= -rdev-requirements.txt
+commands=nosetests tests.py --with-coverage --cover-package=jsonrpclib


### PR DESCRIPTION
Running tests with tox actually packs the egg and installs it for testing which would have caught your recent pypi bundle issues.