### PR TITLE
Pass down API version in SimpleJSONRPCServer.

### DIFF
--- a/jsonrpclib/SimpleJSONRPCServer.py
+++ b/jsonrpclib/SimpleJSONRPCServer.py
@@ -106,6 +106,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
             return None
         try:
             response = jsonrpclib.dumps(response,
+                                        version=get_version(request),
                                         methodresponse=True,
                                         rpcid=request['id']
                                         )


### PR DESCRIPTION
JSON-RPC version 1.0 requires the `error` key to be set in the response even if there is no error.  This is correctly implemented in `Payload.response` - but for that to work, the API version has to be passed down in `SimpleJSONRPCServer` when it calls `dumps` to construct the response.  This was missing, so that JSON-RPC 1.0 requests were answered with a 2.0 response.